### PR TITLE
Include the name of the key that's missing from the Info dict.

### DIFF
--- a/lib/preflight/rules/info_has_keys.rb
+++ b/lib/preflight/rules/info_has_keys.rb
@@ -26,7 +26,7 @@ module Preflight
         info = ohash.object(ohash.trailer[:Info])
         missing = @keys - info.keys
         missing.map { |key|
-          Issue.new("Info dict missing required key", self, :key => key)
+          Issue.new("Info dict missing required key #{key}", self, :key => key)
         }
       end
     end

--- a/lib/preflight/rules/match_info_entries.rb
+++ b/lib/preflight/rules/match_info_entries.rb
@@ -26,7 +26,7 @@ module Preflight
         info = ohash.object(ohash.trailer[:Info])
         @matches.each do |key, regexp|
           if !info.has_key?(key)
-            array << Issue.new("Info dict missing required key", self, :key => key)
+            array << Issue.new("Info dict missing required key #{key}", self, :key => key)
           elsif !info[key].to_s.match(regexp)
             array << Issue.new("value of Info entry #{key} doesn't match #{regexp}", self, :key    => key,
                                                                                            :regexp => regexp)


### PR DESCRIPTION
Small change to have the Info dict key rules follow the same behaviour of the root dict key rule in displaying the name of the key found to be missing.
