### PR TITLE
Fixes rules when the optional Info dictionary is not found, rather than raising exception.

### DIFF
--- a/lib/preflight/rules/info_has_keys.rb
+++ b/lib/preflight/rules/info_has_keys.rb
@@ -26,7 +26,7 @@ module Preflight
         array = []
         info = ohash.object(ohash.trailer[:Info])
         if info.nil?
-          array << Issue.new("Info dict definition is missing", self, :key => key)
+          array << Issue.new("Info dict definition is missing", self)
         else
           missing = @keys - info.keys
           missing.map { |key|

--- a/lib/preflight/rules/info_has_keys.rb
+++ b/lib/preflight/rules/info_has_keys.rb
@@ -23,11 +23,17 @@ module Preflight
       end
 
       def check_hash(ohash)
+        array = []
         info = ohash.object(ohash.trailer[:Info])
-        missing = @keys - info.keys
-        missing.map { |key|
-          Issue.new("Info dict missing required key", self, :key => key)
-        }
+        if info.nil?
+          array << Issue.new("Info dict definition is missing", self, :key => key)
+        else
+          missing = @keys - info.keys
+          missing.map { |key|
+            array << Issue.new("Info dict missing required key", self, :key => key)
+          }
+        end
+        array
       end
     end
   end

--- a/lib/preflight/rules/info_specifies_trapping.rb
+++ b/lib/preflight/rules/info_specifies_trapping.rb
@@ -18,15 +18,18 @@ module Preflight
     class InfoSpecifiesTrapping
 
       def check_hash(ohash)
+        array = []
         info = ohash.object(ohash.trailer[:Info])
-
-        if !info.has_key?(:Trapped)
-          [ Issue.new("Info dict does not specify Trapped", self) ]
-        elsif info[:Trapped] != :True && info[:Trapped] != :False
-          [ Issue.new("Trapped value of Info dict must be True or False", self) ]
+        if info.nil?
+          array << Issue.new("Info dict definition is missing", self, :key => key)
         else
-          []
+          if !info.has_key?(:Trapped)
+            array << Issue.new("Info dict does not specify Trapped", self)
+          elsif info[:Trapped] != :True && info[:Trapped] != :False
+            array << Issue.new("Trapped value of Info dict must be True or False", self)
+          end
         end
+        array
       end
     end
   end

--- a/lib/preflight/rules/info_specifies_trapping.rb
+++ b/lib/preflight/rules/info_specifies_trapping.rb
@@ -21,7 +21,7 @@ module Preflight
         array = []
         info = ohash.object(ohash.trailer[:Info])
         if info.nil?
-          array << Issue.new("Info dict definition is missing", self, :key => key)
+          array << Issue.new("Info dict definition is missing", self)
         else
           if !info.has_key?(:Trapped)
             array << Issue.new("Info dict does not specify Trapped", self)

--- a/lib/preflight/rules/match_info_entries.rb
+++ b/lib/preflight/rules/match_info_entries.rb
@@ -25,7 +25,9 @@ module Preflight
         array = []
         info = ohash.object(ohash.trailer[:Info])
         @matches.each do |key, regexp|
-          if !info.has_key?(key)
+          if info.nil?
+            array << Issue.new("Info dict definition is missing", self, :key => key)
+          elsif !info.has_key?(key)
             array << Issue.new("Info dict missing required key", self, :key => key)
           elsif !info[key].to_s.match(regexp)
             array << Issue.new("value of Info entry #{key} doesn't match #{regexp}", self, :key    => key,

--- a/lib/preflight/rules/match_info_entries.rb
+++ b/lib/preflight/rules/match_info_entries.rb
@@ -24,14 +24,16 @@ module Preflight
       def check_hash(ohash)
         array = []
         info = ohash.object(ohash.trailer[:Info])
-        @matches.each do |key, regexp|
-          if info.nil?
-            array << Issue.new("Info dict definition is missing", self, :key => key)
-          elsif !info.has_key?(key)
-            array << Issue.new("Info dict missing required key", self, :key => key)
-          elsif !info[key].to_s.match(regexp)
-            array << Issue.new("value of Info entry #{key} doesn't match #{regexp}", self, :key    => key,
-                                                                                           :regexp => regexp)
+        if info.nil?
+            array << Issue.new("Info dict definition is missing", self)
+        else
+          @matches.each do |key, regexp|
+            if !info.has_key?(key)
+              array << Issue.new("Info dict missing required key", self, :key => key)
+            elsif !info[key].to_s.match(regexp)
+              array << Issue.new("value of Info entry #{key} doesn't match #{regexp}", self, :key    => key,
+                                                                                             :regexp => regexp)
+            end
           end
         end
         array


### PR DESCRIPTION
Adds Issue.new("Info dict definition is missing", self) to each response array from #check_hash.